### PR TITLE
Fixes and Readme Update

### DIFF
--- a/Adafruit_Video_Looper/usb_drive.py
+++ b/Adafruit_Video_Looper/usb_drive.py
@@ -12,7 +12,10 @@ class USBDriveReader:
         been automatically mounted for reading videos.
         """
         self._load_config(config)
-        self._mount_dir_state = os.listdir(self._mount_path)
+        try:
+            self._mount_dir_state = os.listdir(self._mount_path)
+        except FileNotFoundError:
+            self._mount_dir_state = []
 
 
     def _load_config(self, config):
@@ -29,11 +32,14 @@ class USBDriveReader:
         """Return true if the file search paths have changed, like when a new
         USB drive is inserted.
         """
-        currrent_state = os.listdir(self._mount_path)
-        changed = currrent_state != self._mount_dir_state
-        self._mount_dir_state = currrent_state
+        try:
+            currrent_state = os.listdir(self._mount_path)
+            changed = currrent_state != self._mount_dir_state
+            self._mount_dir_state = currrent_state
 
-        return changed
+            return changed
+        except FileNotFoundError:
+            return False
 
     def idle_message(self):
         """Return a message to display when idle and no files are found."""

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # pi_video_looper2
-This is a forked & updated version of the original project [pi_video_looper](https://github.com/adafruit/pi_video_looper). It aims to support Raspberry Pi 5 and the latest Raspberry Pi OS.
+This is a forked & updated version of the original project [pi_video_looper](https://github.com/adafruit/pi_video_looper). It aims to support Raspberry Pi 4 & 5 and the latest Raspberry Pi OS.
 
 This version uses VLC as the sole supported video playback engine. omxplayer and hello_video are not supported.
 
-An application to turn your Raspberry Pi 5 into a dedicated looping video playback device.
+An application to turn your Raspberry Pi 4 or 5 into a dedicated looping video playback device.
 Can be used in art installations, fairs, theatre, events, infoscreens, advertisements etc...
 
 Works right out of the box, but also has a lot of customisation options to make it fit your use case. See the [video_looper.ini](https://github.com/adafruit/pi_video_looper2/blob/main/assets/video_looper.ini.template) configuration file for an overview of options. 
@@ -11,9 +11,8 @@ Works right out of the box, but also has a lot of customisation options to make 
 If you miss a feature just post an issue here on Github. (https://github.com/adafruit/pi_video_looper2)
 
 ## Feature Warning
-Not all features from the original pi_video_looper have been implemented or tested yet.
-Current known working functionality is limited to basic directory playback and keyboard controls. 
-Looping, repeating, random playlists, GPIO, and usb_copymode are not implemented yet.
+The datetime display showing between videos during wait_time is not functioning properly in this version.
+All other features from the original pi_video_looper are believed to be tested and working, please file an issue if you find something that isn't.
 
 ## Changelog
 #### new in v0.1.0
@@ -40,6 +39,16 @@ sudo ./install.sh --user myusername
 ```
 
 Default player is vlcplayer.
+
+### Disable USB Auto-mount dialog.
+By default the Raspberry Pi OS file manager displays a pop-up dialog with options for what to do with the files found
+on USB drives that have been inserted. This can overtake and minimize the pi_video_looper program. To disable the
+dialog pop-up:
+
+- Open the File Manager
+- Click Edit -> Preferences
+- Click Volume Management in the left navigation
+- Uncheck the "Show available options for removable media when they are inserted"
 
 ## How to update
 An update is always like a fresh installation so you will lose custom changes made to the /boot/video_looper.ini   

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ wget https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/m
 sed -i '/shell.prompt_reboot()/d' raspi-blinka.py
 /home/$USERNAME/venvs/pi_video_looper2_venv/bin/python raspi-blinka.py
 rm raspi-blinka.py
-rm -r lg/
+rm -rf -- lg/
 
 echo "Installing pi_video_looper2 program..."
 echo "=================================="


### PR DESCRIPTION
- Fix for pi4 - Don't error if `lg/` doesn't exist to remove after blinka install
- Fix for new install - catch FileNotFound error if the media mount path is not found. I.e. looking for `/media/pi/` and when only `/media/` exists on a fresh image before any removable media devices have been connected. 
- Updated readme - Change the feature warning to list the only known feature that isn't working and ask other issues be reported. Also added references to Pi 4 as I have successfully tested on that device now. 